### PR TITLE
Prevent use of " ' " in message and button text

### DIFF
--- a/index.php
+++ b/index.php
@@ -95,8 +95,8 @@ return [
 	                                'theme': '$theme',
                                     'position': '$position',
                                     'content': {
-                                        'message': '$message',
-                                        'dismiss': '$dismiss',
+                                        'message': \"$message\",
+                                        'dismiss': \"$dismiss\",
                                         'link': '$policytext',
                                         'href': '$url'                                                                                
                                     }


### PR DESCRIPTION
Hey !
Nice simple but still effective plugin !

Just wanted to add support for the " ' " character in message and dismiss button text.